### PR TITLE
fixes broken/outdated links about automation in shell lecture

### DIFF
--- a/03-shell/03-shell.Rmd
+++ b/03-shell/03-shell.Rmd
@@ -173,7 +173,7 @@ There are many shell variants, but we're going to focus on [**Bash**](https://ww
 --
 
 We're going to focus on 1, 2 and 3 in this course. That's not to say that 4 is unimportant (far from it!), but we just won't have time to cover it. 
-- [Here](http://stat545.com/Classroom/notes/cm109.nb.html), [here](https://ropenscilabs.github.io/drake-manual/index.html), and [here](https://web.stanford.edu/~gentzkow/research/CodeAndData.pdf) are great places to start learning about automation on your own.
+- [Here](https://stat545.com/automation-overview.html), [here](https://books.ropensci.org/drake/index.html), and [here](https://web.stanford.edu/~gentzkow/research/CodeAndData.pdf) are great places to start learning about automation on your own.
 
 ---
 

--- a/03-shell/03-shell.html
+++ b/03-shell/03-shell.html
@@ -160,7 +160,7 @@ There are many shell variants, but we're going to focus on [**Bash**](https://ww
 --
 
 We're going to focus on 1, 2 and 3 in this course. That's not to say that 4 is unimportant (far from it!), but we just won't have time to cover it. 
-- [Here](http://stat545.com/Classroom/notes/cm109.nb.html), [here](https://ropenscilabs.github.io/drake-manual/index.html), and [here](https://web.stanford.edu/~gentzkow/research/CodeAndData.pdf) are great places to start learning about automation on your own.
+- [Here](https://stat545.com/automation-overview.html), [here](https://books.ropensci.org/drake/index.html), and [here](https://web.stanford.edu/~gentzkow/research/CodeAndData.pdf) are great places to start learning about automation on your own.
 
 ---
 


### PR DESCRIPTION
Stat545 link is broken
Drake link is not broken but redirected to another domain.

Both fixed.

Thanks for making the lectures available.