### PR TITLE
Typo/mistake in slide 44 lecture 5

### DIFF
--- a/05-tidyverse/05-tidyverse.Rmd
+++ b/05-tidyverse/05-tidyverse.Rmd
@@ -696,7 +696,7 @@ economists %>% separate(name, c("first_name", "last_name"))
 
 </br>
 
-This command is pretty smart. But to avoid ambiguity, you can also specify the separation character with `separate(..., sep=".")`.
+This command is pretty smart. But to avoid ambiguity, you can also specify the separation character with `separate(..., sep="\\.")`.
 
 ---
 

--- a/05-tidyverse/05-tidyverse.html
+++ b/05-tidyverse/05-tidyverse.html
@@ -1093,7 +1093,7 @@ economists %&gt;% separate(name, c("first_name", "last_name"))
 
 &lt;/br&gt;
 
-This command is pretty smart. But to avoid ambiguity, you can also specify the separation character with `separate(..., sep=".")`.
+This command is pretty smart. But to avoid ambiguity, you can also specify the separation character with `separate(..., sep="\\.")`.
 
 ---
 


### PR DESCRIPTION
In order to separate the economists' full names by the full stop, the command should (surely?) be separate( ... , sep = "\\\\."), since "." is a regex. 