### PR TITLE
Fix improper logical operators

### DIFF
--- a/04-rlang/04-rlang.Rmd
+++ b/04-rlang/04-rlang.Rmd
@@ -124,8 +124,9 @@ R also comes equipped with a full set of logical operators (and Boolean function
 
 ```{r}
 1 > 2
-1 > 2 | 0.5 ## The "|" stands for "or" (not a pipe a la the shell)
-1 > 2 & 0.5 ## The "&" stands for "and"
+1 > 2 & 1 > 0.5 ## The "&" stands for "and"
+1 > 2 | 1 > 0.5 ## The "|" stands for "or" (not a pipe a la the shell)
+# Note the operator precedence (">" is evaluated before "&" and "|")
 isTRUE (1 < 2)
 ```
 Etc.


### PR DESCRIPTION
I stumbled upon an issue in the introduction to logical operators. Two examples are `1 > 2 | 0.5`, and `1 > 2 & 0.5`. These evaluate to `TRUE` and `FALSE`, with the implication being that `1` is indeed greater than `2 or 0.5`, but not than `2 and 0.5`. However, this is not what happens in the code. Instead, due to operator precedence and type conversion **R** evaluates the first statement as:
```
	1 > 2 | 0.5
	FALSE | 0.5
	FALSE | TRUE
	TRUE
```
And the second statement as:
```
	1 > 2 & 0.5
	FALSE & 0.5
	FALSE & TRUE
	FALSE
```
To verify this you can run e.g.:
```
	5 > 2 & 10 # TRUE
	5 > 10 & 2 # FALSE
	5 < 2 | 10 # TRUE
```

I have adapted the examples to work properly (`1 > 2 | 1 > 0.5`) and added a comment on operator precedence.
